### PR TITLE
test(chat): add chat related tests

### DIFF
--- a/lib/core/constants/keys.dart
+++ b/lib/core/constants/keys.dart
@@ -84,3 +84,15 @@ class ChatKeys {
       ValueKey('-message');
   static const ValueKey<String> chatAvatarPostfix = ValueKey('-avatar');
 }
+
+class MessageKeys {
+  static const ValueKey<String> messagePrefix = ValueKey('message-');
+  static const ValueKey<String> messageSenderPostfix = ValueKey('-sender');
+  static const ValueKey<String> messageContentPostfix = ValueKey('-content');
+  static const ValueKey<String> messageTimePostfix = ValueKey('-time');
+  static const ValueKey<String> messageStatusPostfix = ValueKey('-status');
+  static const ValueKey<String> messageReplyPostfix = ValueKey('-reply');
+  static const ValueKey<String> messageForwardPostfix = ValueKey('-forward');
+  static const ValueKey<String> messageCopyPostfix = ValueKey('-copy');
+  static const ValueKey<String> messageDeletePostfix = ValueKey('-delete');
+}

--- a/lib/core/constants/keys.dart
+++ b/lib/core/constants/keys.dart
@@ -67,3 +67,20 @@ class ChangeEmailKeys {
   static final emailShakeKey =
       GlobalKey<ShakeWidgetState>(debugLabel: 'change_email_shake');
 }
+
+class ChatKeys {
+  static const ValueKey<String> chatTilePrefix = ValueKey('chat-tile-');
+  static const ValueKey<String> chatMessagePrefix = ValueKey('chat-message-');
+  static const ValueKey<String> chatNamePostfix = ValueKey('-name');
+  static const ValueKey<String> chatTileDisplayTextPostfix =
+      ValueKey('-display-text');
+  static const ValueKey<String> chatTileDisplayTimePostfix =
+      ValueKey('-display-time');
+  static const ValueKey<String> chatTileDisplayUnreadCountPostfix =
+      ValueKey('-display-unread-count');
+  static const ValueKey<String> chatTileMentionPostfix = ValueKey('-mention');
+  static const ValueKey<String> chatTileMutePostfix = ValueKey('-mute');
+  static const ValueKey<String> chatTileMessageStatusPostfix =
+      ValueKey('-message');
+  static const ValueKey<String> chatAvatarPostfix = ValueKey('-avatar');
+}

--- a/lib/core/constants/keys.dart
+++ b/lib/core/constants/keys.dart
@@ -69,6 +69,10 @@ class ChangeEmailKeys {
 }
 
 class ChatKeys {
+  static const ValueKey<String> chatSearchButton = ValueKey('chat-search-button');
+  static const ValueKey<String> chatSearchInput = ValueKey('chat-search-input');
+  static const ValueKey<String> chatSearchShowMode = ValueKey('chat-search-show-mode');
+  static const ValueKey<String> chatSearchDatePicker = ValueKey('chat-search-date-picker');
   static const ValueKey<String> chatTilePrefix = ValueKey('chat-tile-');
   static const ValueKey<String> chatMessagePrefix = ValueKey('chat-message-');
   static const ValueKey<String> chatNamePostfix = ValueKey('-name');

--- a/lib/core/utils.dart
+++ b/lib/core/utils.dart
@@ -193,7 +193,7 @@ List<MapEntry<int, int>> kmp(String text, String pattern) {
   print(pattern);
   final int n = text.length;
   final int m = pattern.length;
-  if (m == 0) return const [MapEntry(0, 0)];
+  if (m == 0) return const [];
   List<int> lps = _computeLPSArray(pattern.toLowerCase());
   int i = 0; // index for text[]
   int j = 0; // index for pattern[]

--- a/lib/features/chat/view/screens/chat_screen.dart
+++ b/lib/features/chat/view/screens/chat_screen.dart
@@ -209,6 +209,7 @@ class _ChatScreen extends ConsumerState<ChatScreen> with WidgetsBindingObserver 
           imageBytes: imageBytes,
         ) :
         TextField(
+          key: ChatKeys.chatSearchInput,
           autofocus: true,
           decoration: const InputDecoration(
             hintText: 'Search',
@@ -272,6 +273,7 @@ class _ChatScreen extends ConsumerState<ChatScreen> with WidgetsBindingObserver 
                   ),
                 ),
                 const PopupMenuItem<String>(
+                  key: ChatKeys.chatSearchButton,
                   value: 'search',
                   padding: EdgeInsets.zero,
                   height: menuItemsHeight,
@@ -437,7 +439,8 @@ class _ChatScreen extends ConsumerState<ChatScreen> with WidgetsBindingObserver 
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [
                         IconButton(
-                          icon: Icon(Icons.edit_calendar),
+                          key: ChatKeys.chatSearchDatePicker,
+                          icon: const Icon(Icons.edit_calendar),
                           onPressed: () {
                             // Show the Cupertino Date Picker when the icon is pressed
                             DatePicker.showDatePicker(
@@ -476,7 +479,7 @@ class _ChatScreen extends ConsumerState<ChatScreen> with WidgetsBindingObserver 
                           isShowAsList ?
                           '$_numberOfMatches result${_numberOfMatches != 1 ? 's' :''}' :
                           '$_currentMatch of $_numberOfMatches',
-                          style: TextStyle(
+                          style: const TextStyle(
                             color: Palette.primaryText,
                             fontWeight: FontWeight.w500
                           ),
@@ -489,6 +492,7 @@ class _ChatScreen extends ConsumerState<ChatScreen> with WidgetsBindingObserver 
                                 _toggleSearchDisplay();
                               },
                               child: Text(
+                                key: ChatKeys.chatSearchShowMode,
                                 isShowAsList ? 'Show as Chat' : 'Show as List',
                                 style: const TextStyle(
                                   color: Palette.accent,

--- a/lib/features/chat/view/screens/chat_screen.dart
+++ b/lib/features/chat/view/screens/chat_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_cupertino_datetime_picker/flutter_cupertino_datetime_picker.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'package:intl/intl.dart';
+import 'package:telware_cross_platform/core/constants/keys.dart';
 import 'package:telware_cross_platform/core/models/chat_model.dart';
 import 'package:telware_cross_platform/core/models/message_model.dart';
 import 'package:telware_cross_platform/core/providers/user_provider.dart';
@@ -180,6 +181,7 @@ class _ChatScreen extends ConsumerState<ChatScreen> with WidgetsBindingObserver 
           chatModel.id != null ? chatModel.messages : <MessageModel>[];
       chatContent = _generateChatContentWithDateLabels(messages);
     const menuItemsHeight = 45.0;
+    var messagesIndex = 0;
 
     return Scaffold(
       appBar: AppBar(
@@ -410,6 +412,7 @@ class _ChatScreen extends ConsumerState<ChatScreen> with WidgetsBindingObserver 
                             return item;
                           } else if (item is MessageModel) {
                             return MessageTileWidget(
+                              key: ValueKey('${MessageKeys.messagePrefix}${messagesIndex++}'),
                               messageModel: item,
                               isSentByMe: item.senderId == ref.read(userProvider)!.id,
                               showInfo: type == ChatType.group,

--- a/lib/features/chat/view/widget/chat_tile_widget.dart
+++ b/lib/features/chat/view/widget/chat_tile_widget.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:telware_cross_platform/core/constants/keys.dart';
 import 'package:telware_cross_platform/core/models/chat_model.dart';
 import 'package:telware_cross_platform/core/models/message_model.dart';
 import 'package:telware_cross_platform/core/routes/routes.dart';
@@ -25,10 +26,10 @@ class ChatTileWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final keyValue = (key as ValueKey).value;
     final imageBytes = chatModel.photoBytes;
     final hasDraft = chatModel.draft?.isNotEmpty ?? false;
     final isGroupChat = chatModel.type == ChatType.group;
-    final messageStateIcon = sentByUser ? Icon(getMessageStateIcon(displayMessage), size: 16, color: Palette.accent,) : null;
     final unreadCount = _getUnreadMessageCount();
     final isMuted = chatModel.isMuted;
     final isMentioned = chatModel.isMentioned;
@@ -42,6 +43,7 @@ class ChatTileWidget extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.only(right: 12.0, left: 12.0, top: 8.0, bottom: 8.0),
               child: CircleAvatar(
+                key: ValueKey("$keyValue${ChatKeys.chatAvatarPostfix.value}"),
                 radius: 28,
                 backgroundImage: imageBytes != null ? MemoryImage(imageBytes) : null,
                 backgroundColor: imageBytes == null ? Palette.primary : null,
@@ -69,6 +71,7 @@ class ChatTileWidget extends StatelessWidget {
                           children: [
                             Expanded(
                               child: Text(
+                                key: ValueKey("$keyValue${ChatKeys.chatNamePostfix.value}"),
                                 chatModel.title,
                                 style: const TextStyle(
                                   color: Palette.primaryText,
@@ -80,20 +83,27 @@ class ChatTileWidget extends StatelessWidget {
                               ),
                             ),
                             if (isMuted)
-                              const Padding(
-                                padding: EdgeInsets.only(right: 2.0),
+                              Padding(
+                                padding: const EdgeInsets.only(right: 2.0),
                                 child: Icon(
+                                  key: ValueKey("$keyValue${ChatKeys.chatTileMutePostfix.value}"),
                                   Icons.volume_off,
                                   size: 18,
                                   color: Palette.inactiveSwitch,
                                 ),
                               ),
-                            if (messageStateIcon != null)
+                            if (sentByUser)
                               Padding(
                                 padding: const EdgeInsets.only(right: 2.0),
-                                child: messageStateIcon,
+                                child: Icon(
+                                  key: ValueKey("$keyValue${ChatKeys.chatTileMessageStatusPostfix.value}"),
+                                  getMessageStateIcon(displayMessage),
+                                  size: 16,
+                                  color: Palette.accent,
+                                ),
                               ),
                             Text(
+                              key: ValueKey("$keyValue${ChatKeys.chatTileDisplayTimePostfix.value}"),
                               formatTimestamp(displayMessage.timestamp),
                               style: const TextStyle(
                                 color: Colors.grey,
@@ -110,6 +120,7 @@ class ChatTileWidget extends StatelessWidget {
                             // Displayed message content
                             Expanded(
                               child: RichText(
+                                key: ValueKey("$keyValue${ChatKeys.chatTileDisplayTextPostfix.value}"),
                                 text: TextSpan(
                                   style: const TextStyle(
                                     fontSize: 14,
@@ -144,9 +155,10 @@ class ChatTileWidget extends StatelessWidget {
 
                             if (unreadCount > 0) ...[
                               if (isMentioned)
-                                const Padding(
-                                  padding: EdgeInsets.only(left: 8.0),
+                                Padding(
+                                  padding: const EdgeInsets.only(left: 8.0),
                                   child: Icon(
+                                    key: ValueKey("$keyValue${ChatKeys.chatTileMentionPostfix.value}"),
                                     Icons.alternate_email_rounded,
                                     size: 18,
                                     color: Palette.primary,
@@ -161,6 +173,7 @@ class ChatTileWidget extends StatelessWidget {
                                     borderRadius: BorderRadius.circular(12.0),
                                   ),
                                   child: Text(
+                                    key: ValueKey("$keyValue${ChatKeys.chatTileDisplayUnreadCountPostfix.value}"),
                                     unreadCount.toString(),
                                     style: const TextStyle(
                                       color: Palette.primaryText,

--- a/lib/features/chat/view/widget/message_tile_widget.dart
+++ b/lib/features/chat/view/widget/message_tile_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:telware_cross_platform/core/constants/keys.dart';
 import 'package:telware_cross_platform/core/models/message_model.dart';
 import 'package:telware_cross_platform/core/theme/palette.dart';
 import 'package:telware_cross_platform/core/utils.dart';
@@ -32,10 +33,12 @@ class MessageTileWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final keyValue = (key as ValueKey).value;
     Alignment messageAlignment = isSentByMe ? Alignment.centerRight : Alignment.centerLeft;
     IconData messageState = getMessageStateIcon(messageModel);
     Widget senderNameWidget = showInfo && !isSentByMe
         ? Text(
+      key: ValueKey('$keyValue${MessageKeys.messageSenderPostfix.value}'),
       messageModel.senderId,
       style: TextStyle(
         fontWeight: FontWeight.bold,
@@ -74,6 +77,7 @@ class MessageTileWidget extends StatelessWidget {
                 Wrap(
                   children: [
                     HighlightTextWidget(
+                      key: ValueKey('$keyValue${MessageKeys.messageContentPostfix.value}'),
                       text: messageModel.content ?? "",
                       normalStyle: const TextStyle(
                         color: Palette.primaryText,
@@ -102,6 +106,7 @@ class MessageTileWidget extends StatelessWidget {
                   child: Row(
                     children: [
                       Text(
+                        key: ValueKey('$keyValue${MessageKeys.messageTimePostfix.value}'),
                         formatTimestamp(messageModel.timestamp),
                         style: TextStyle(
                           fontSize: 11,
@@ -111,6 +116,7 @@ class MessageTileWidget extends StatelessWidget {
                       if (isSentByMe) ...[
                         const SizedBox(width: 4),
                         Icon(
+                          key: ValueKey('$keyValue${MessageKeys.messageStatusPostfix.value}'),
                           messageState,
                           size: 12,
                           color: Palette.primaryText

--- a/lib/features/stories/view/widget/chats_list.dart
+++ b/lib/features/stories/view/widget/chats_list.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:telware_cross_platform/core/constants/keys.dart';
 import 'package:telware_cross_platform/core/models/chat_model.dart';
 import 'package:telware_cross_platform/core/providers/user_provider.dart';
 import 'package:telware_cross_platform/features/chat/view/widget/chat_tile_widget.dart';
@@ -18,6 +19,7 @@ class ChatsList extends ConsumerWidget {
       delegate: SliverChildBuilderDelegate(
         (BuildContext context, int index) {
           return _delegate(
+            ValueKey(ChatKeys.chatTilePrefix.value + index.toString()),
             chatsList[index],
             ref.read(userProvider)!.id!,
           );
@@ -27,10 +29,11 @@ class ChatsList extends ConsumerWidget {
     );
   }
 
-  Widget _delegate(ChatModel chat, String userID) {
+  Widget _delegate(ValueKey key, ChatModel chat, String userID) {
     final message = chat.messages[0];
 
     return ChatTileWidget(
+      key: key,
       chatModel: chat,
       displayMessage: message,
       sentByUser: message.senderId != userID,

--- a/test/core/utils_test.dart
+++ b/test/core/utils_test.dart
@@ -266,4 +266,74 @@ void main() {
       expect(formatTimestamp(timestamp), expectedFormat);
     });
   });
+
+  group("kmp string matching", () {
+    test("returns the correct index of the substring", () {
+      String inputText = "ababcababcabcabc";
+      String searchText = "ababcabcabc";
+
+      final expectedOutput = [{5: searchText.length}];
+      final result = kmp(inputText, searchText);
+
+      expect(
+        result.map((e) => Map.fromEntries([e])).toList(),
+        expectedOutput.map((e) => Map.fromEntries([e.entries.first])).toList(),
+        reason: "Expected to find the substring at index 5",
+      );
+    });
+
+    test("returns [MapEntry(0, 0)] when no match is found", () {
+      String inputText = "abcdef";
+      String searchText = "ghij";
+
+      final expectedOutput = [];
+      final result = kmp(inputText, searchText);
+
+      expect(result.map((e) => Map.fromEntries([e])).toList(), expectedOutput,
+          reason: "Expected [MapEntry(0, 0)] when no match is found");
+    });
+
+    test("handles edge case with empty search string", () {
+      String inputText = "abcdef";
+      String searchText = "";
+
+      final expectedOutput = [];
+      final result = kmp(inputText, searchText);
+
+      expect(result.map((e) => Map.fromEntries([e])).toList(), expectedOutput,
+          reason: "Expected [MapEntry(0, 0)] for an empty search string");
+    });
+
+    test("handles multiple matches in input text", () {
+      String inputText = "abcabcabc";
+      String searchText = "abc";
+
+      final expectedOutput = [
+        {0: searchText.length},
+        {3: searchText.length},
+        {6: searchText.length}
+      ];
+      final result = kmp(inputText, searchText);
+
+      expect(
+        result.map((e) => Map.fromEntries([e])).toList(),
+        expectedOutput.map((e) => Map.fromEntries([e.entries.first])).toList(),
+        reason: "Expected multiple matches for repeating patterns",
+      );
+    });
+
+    test("returns correct index when input is the same as search text", () {
+      String inputText = "abc";
+      String searchText = "abc";
+
+      final expectedOutput = [{0: searchText.length}];
+      final result = kmp(inputText, searchText);
+
+      expect(
+        result.map((e) => Map.fromEntries([e])).toList(),
+        expectedOutput.map((e) => Map.fromEntries([e.entries.first])).toList(),
+        reason: "Expected a match at index 0 for identical input and search strings",
+      );
+    });
+  });
 }

--- a/test/features/chat/widgets/chat_tile_widget_test.dart
+++ b/test/features/chat/widgets/chat_tile_widget_test.dart
@@ -1,0 +1,234 @@
+import 'package:faker/faker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:telware_cross_platform/core/constants/keys.dart';
+import 'package:telware_cross_platform/core/models/chat_model.dart';
+import 'package:telware_cross_platform/core/models/message_model.dart';
+import 'package:telware_cross_platform/features/chat/enum/chatting_enums.dart';
+import 'package:telware_cross_platform/features/chat/enum/message_enums.dart';
+import 'package:telware_cross_platform/features/chat/view/widget/chat_tile_widget.dart';
+
+String extractTextFromRichText(RichText richText) {
+  final textSpan = richText.text as TextSpan;
+  return _extractTextSpan(textSpan);
+}
+
+String _extractTextSpan(TextSpan textSpan) {
+  final buffer = StringBuffer();
+  textSpan.visitChildren((span) {
+    if (span is TextSpan) {
+      buffer.write(span.text);
+      // Recursively visit children if they exist
+      if (span.children != null) {
+        for (var child in span.children!) {
+          buffer.write(_extractTextSpan(child as TextSpan));
+        }
+      }
+    }
+    return true; // Continue visiting
+  });
+  return buffer.toString();
+}
+
+void main() {
+  Faker faker = Faker();
+  group('Chat Tile Widget Tests', () {
+    testWidgets("renders chat tile", (WidgetTester tester) async {
+      MessageModel message = MessageModel(
+        id: '1',
+        senderId: '1',
+        content: 'Hello',
+        timestamp: DateTime.now(),
+        messageType: MessageType.normal,
+      );
+      const index = '0';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ChatTileWidget(
+              key: ValueKey("${ChatKeys.chatTilePrefix.value}$index"),
+              chatModel: ChatModel(
+                id: faker.guid.guid(),
+                title: 'Chat 1',
+                messages: [message],
+                userIds: [faker.guid.guid()],
+                type: ChatType.private,
+              ),
+              displayMessage: message,
+              sentByUser: false,
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(ValueKey(ChatKeys.chatTilePrefix.value +
+          index)), findsOneWidget,
+          reason: 'Expected chat tile to render.');
+      expect(find.byKey(ValueKey(ChatKeys.chatTilePrefix.value +
+          index + ChatKeys.chatNamePostfix.value)), findsOneWidget,
+          reason: 'Expected chat title to render.');
+      expect(find.byKey(ValueKey(ChatKeys.chatTilePrefix.value +
+          index + ChatKeys.chatTileDisplayTextPostfix.value)), findsOneWidget,
+          reason: 'Expected chat message to render.');
+      expect(find.byKey(ValueKey(ChatKeys.chatTilePrefix.value +
+          index + ChatKeys.chatAvatarPostfix.value)), findsOneWidget,
+          reason: 'Expected chat avatar to render.');
+      expect(find.byKey(ValueKey(ChatKeys.chatTilePrefix.value +
+          index + ChatKeys.chatTileDisplayTimePostfix.value)), findsOneWidget,
+          reason: 'Expected chat time to render.');
+    });
+
+    testWidgets("renders chat tile with different chat types", (WidgetTester tester) async {
+      MessageModel message = MessageModel(
+        id: '1',
+        senderId: '1',
+        content: 'Hello',
+        timestamp: DateTime.now(),
+        messageType: MessageType.normal,
+      );
+      final chats = [
+        ChatModel(
+          id: faker.guid.guid(),
+          title: 'Chat 1',
+          messages: [message],
+          userIds: [faker.guid.guid()],
+          type: ChatType.private,
+        ),
+        ChatModel(
+          id: faker.guid.guid(),
+          title: 'Chat 2',
+          messages: [message],
+          userIds: [faker.guid.guid()],
+          type: ChatType.group,
+        ),
+        ChatModel(
+          id: faker.guid.guid(),
+          title: 'Chat 3',
+          messages: [message],
+          userIds: [faker.guid.guid()],
+          type: ChatType.channel,
+        ),
+      ];
+      var index = 0;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children:chats.map((chat) {
+                return ChatTileWidget(
+                  key: ValueKey("${ChatKeys.chatTilePrefix.value}${index++}"),
+                  chatModel: chat,
+                  displayMessage: message,
+                  sentByUser: false,
+                );
+              }).toList(),
+            )
+          ),
+        ),
+      );
+      for (int i = 0; i < 3; i++) {
+        expect(find.byKey(ValueKey('${ChatKeys.chatTilePrefix.value}$i')), findsOneWidget,
+            reason: 'Expected chat tile to render.');
+        expect(find.byKey(ValueKey('${ChatKeys.chatTilePrefix.value}$i${ChatKeys.chatTileDisplayTextPostfix.value}')), findsOneWidget,
+            reason: 'Expected chat message to render.');
+      }
+      Finder displayedTextFind = find.byKey(ValueKey('${ChatKeys.chatTilePrefix.value}1${ChatKeys.chatTileDisplayTextPostfix.value}'));
+      RichText displayedTextWidget = tester.firstWidget(displayedTextFind);
+      expect(extractTextFromRichText(displayedTextWidget), '${'John Doe'.split(" ")[0]}: ${message.content}',
+          reason: 'Expected chat message to render with sender ID in group chat ${chats[1].type}.');
+      displayedTextFind = find.byKey(ValueKey('${ChatKeys.chatTilePrefix.value}0${ChatKeys.chatTileDisplayTextPostfix.value}'));
+      displayedTextWidget = tester.firstWidget(displayedTextFind);
+      expect(extractTextFromRichText(displayedTextWidget), message.content,
+          reason: 'Expected chat message to render normally in private chat.');
+      displayedTextFind = find.byKey(ValueKey('${ChatKeys.chatTilePrefix.value}2${ChatKeys.chatTileDisplayTextPostfix.value}'));
+      displayedTextWidget = tester.firstWidget(displayedTextFind);
+      expect(extractTextFromRichText(displayedTextWidget), message.content,
+          reason: 'Expected chat message to render normally in channel chat.');
+    });
+
+    testWidgets("renders chat draft", (WidgetTester tester) async {
+      MessageModel message = MessageModel(
+        id: '1',
+        senderId: '1',
+        content: 'Hello',
+        timestamp: DateTime.now(),
+        messageType: MessageType.normal,
+      );
+      ChatModel chat = ChatModel(
+        id: faker.guid.guid(),
+        title: 'Chat 1',
+        messages: [message],
+        userIds: [faker.guid.guid()],
+        type: ChatType.private,
+        draft: 'This is a draft message',
+      );
+      const index = '0';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ChatTileWidget(
+              key: ValueKey("${ChatKeys.chatTilePrefix.value}$index"),
+              chatModel: chat,
+              displayMessage: message,
+              sentByUser: false,
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(ValueKey(ChatKeys.chatTilePrefix.value +
+          index + ChatKeys.chatTileDisplayTextPostfix.value)), findsOneWidget,
+          reason: 'Expected chat display text to render.');
+      Finder displayedTextFind = find.byKey(ValueKey('${ChatKeys.chatTilePrefix.value}$index${ChatKeys.chatTileDisplayTextPostfix.value}'));
+      RichText displayedTextWidget = tester.firstWidget(displayedTextFind);
+      expect(extractTextFromRichText(displayedTextWidget), 'Draft: ${chat.draft}',
+          reason: 'Expected chat message to render with draft message.');
+    });
+
+    testWidgets("renders message status only if it was sent by the user", (WidgetTester tester) async {
+      MessageModel message = MessageModel(
+        id: '1',
+        senderId: '1',
+        content: 'Hello',
+        timestamp: DateTime.now(),
+        messageType: MessageType.normal,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                ChatTileWidget(
+                  key: ValueKey("${ChatKeys.chatTilePrefix.value}0"),
+                  chatModel: ChatModel(
+                    id: faker.guid.guid(),
+                    title: 'Chat 1',
+                    messages: [message],
+                    userIds: [faker.guid.guid()],
+                    type: ChatType.private,
+                  ),
+                  displayMessage: message,
+                  sentByUser: true,
+                ),
+                ChatTileWidget(
+                  key: ValueKey("${ChatKeys.chatTilePrefix.value}1"),
+                  chatModel: ChatModel(
+                    id: faker.guid.guid(),
+                    title: 'Chat 1',
+                    messages: [message],
+                    userIds: [faker.guid.guid()],
+                    type: ChatType.private,
+                  ),
+                  displayMessage: message,
+                  sentByUser: false,
+                )
+              ],
+            ),
+          ),
+        ),
+      );
+      expect(find.byKey(ValueKey('${ChatKeys.chatTilePrefix.value}0${ChatKeys.chatTileMessageStatusPostfix.value}')), findsOneWidget,
+          reason: 'Expected message status to render if sent by user.');
+      expect(find.byKey(ValueKey('${ChatKeys.chatTilePrefix.value}1${ChatKeys.chatTileMessageStatusPostfix.value}')), findsNothing,
+          reason: 'Expected message status not to render if not sent by user.');
+    });
+  });
+}

--- a/test/features/chat/widgets/message_tile_widget_test.dart
+++ b/test/features/chat/widgets/message_tile_widget_test.dart
@@ -1,0 +1,181 @@
+import 'package:faker/faker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart';
+import 'package:telware_cross_platform/core/constants/keys.dart';
+import 'package:telware_cross_platform/core/models/chat_model.dart';
+import 'package:telware_cross_platform/core/models/message_model.dart';
+import 'package:telware_cross_platform/core/view/widget/highlight_text_widget.dart';
+import 'package:telware_cross_platform/features/chat/enum/chatting_enums.dart';
+import 'package:telware_cross_platform/features/chat/enum/message_enums.dart';
+import 'package:telware_cross_platform/features/chat/view/widget/message_tile_widget.dart';
+
+String extractTextFromRichText(RichText richText) {
+  final textSpan = richText.text as TextSpan;
+  return _extractTextSpan(textSpan);
+}
+
+String _extractTextSpan(TextSpan textSpan) {
+  final buffer = StringBuffer();
+  textSpan.visitChildren((span) {
+    if (span is TextSpan) {
+      buffer.write(span.text);
+      // Recursively visit children if they exist
+      if (span.children != null) {
+        for (var child in span.children!) {
+          buffer.write(_extractTextSpan(child as TextSpan));
+        }
+      }
+    }
+    return true; // Continue visiting
+  });
+  return buffer.toString();
+}
+
+void main() {
+  Faker faker = Faker();
+  group('Message Tile Widget Tests', () {
+    testWidgets("renders message tile", (WidgetTester tester) async {
+      MessageModel message = MessageModel(
+        id: '1',
+        senderId: '1',
+        content: 'Hello',
+        timestamp: DateTime.now(),
+        messageType: MessageType.normal,
+      );
+      const index = '0';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MessageTileWidget(
+              key: ValueKey("${ChatKeys.chatTilePrefix.value}$index"),
+              messageModel: message,
+              isSentByMe: false,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(ValueKey("${ChatKeys.chatTilePrefix.value}$index")), findsOneWidget,
+          reason: "Expected message tile to render");
+
+      expect(find.byKey(ValueKey("${ChatKeys.chatTilePrefix.value}$index${MessageKeys.messageContentPostfix.value}")), findsOneWidget,
+          reason: "Expected message content to render");
+
+      expect(find.byKey(ValueKey("${ChatKeys.chatTilePrefix.value}$index${MessageKeys.messageTimePostfix.value}")), findsOneWidget,
+          reason: "Expected message timestamp to render");
+    });
+
+    testWidgets("renders message tile with rich text", (WidgetTester tester) async {
+      MessageModel message = MessageModel(
+        id: '1',
+        senderId: '1',
+        content: 'Hello',
+        timestamp: DateTime.now(),
+        messageType: MessageType.normal,
+      );
+      const index = '0';
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: MessageTileWidget(
+              key: ValueKey("${ChatKeys.chatTilePrefix.value}$index"),
+              messageModel: message,
+              isSentByMe: false,
+            ),
+          ),
+        ),
+      );
+
+      final Finder highlightTextFinder = find.byKey(ValueKey("${ChatKeys.chatTilePrefix.value}$index${MessageKeys.messageContentPostfix.value}"));
+      final Finder richTextFinder = find.descendant(
+        of: highlightTextFinder,
+        matching: find.byType(RichText),
+      );
+      expect(richTextFinder, findsOneWidget);
+      final RichText richText = tester.firstWidget(richTextFinder) as RichText;
+      expect(extractTextFromRichText(richText), message.content,
+          reason: "Expected message content to render as rich text");
+    });
+
+    testWidgets("renders message tile with message status if sent by user", (WidgetTester tester) async {
+      MessageModel message = MessageModel(
+        id: '1',
+        senderId: '1',
+        content: 'Hello',
+        timestamp: DateTime.now(),
+        messageType: MessageType.normal,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                MessageTileWidget(
+                  key: ValueKey("${ChatKeys.chatTilePrefix.value}0"),
+                  messageModel: message,
+                  isSentByMe: true,
+                ),
+                MessageTileWidget(
+                  key: ValueKey("${ChatKeys.chatTilePrefix.value}1"),
+                  messageModel: message,
+                  isSentByMe: false,
+                ),
+              ],
+            )
+          ),
+        ),
+      );
+
+      expect(find.byKey(ValueKey("${ChatKeys.chatTilePrefix.value}0${MessageKeys.messageStatusPostfix.value}")), findsOneWidget,
+          reason: "Expected message status to render");
+      expect(find.byKey(ValueKey("${ChatKeys.chatTilePrefix.value}1${MessageKeys.messageStatusPostfix.value}")), findsNothing,
+          reason: "Expected message status to not render");
+    });
+
+    testWidgets("renders message sender if enabled", (WidgetTester tester) async {
+      MessageModel message = MessageModel(
+        id: '1',
+        senderId: '1',
+        content: 'Hello',
+        timestamp: DateTime.now(),
+        messageType: MessageType.normal,
+      );
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                MessageTileWidget(
+                  key: ValueKey("${ChatKeys.chatTilePrefix.value}0"),
+                  messageModel: message,
+                  isSentByMe: false,
+                  showInfo: true,
+                ),
+                MessageTileWidget(
+                  key: ValueKey("${ChatKeys.chatTilePrefix.value}1"),
+                  messageModel: message,
+                  isSentByMe: false,
+                  showInfo: false,
+                ),
+                MessageTileWidget(
+                  key: ValueKey("${ChatKeys.chatTilePrefix.value}2"),
+                  messageModel: message,
+                  isSentByMe: true,
+                  showInfo: true,
+                ),
+              ],
+            )
+          ),
+        ),
+      );
+
+      expect(find.byKey(ValueKey("${ChatKeys.chatTilePrefix.value}0${MessageKeys.messageSenderPostfix.value}")), findsOneWidget,
+          reason: "Expected message sender to render");
+      expect(find.byKey(ValueKey("${ChatKeys.chatTilePrefix.value}1${MessageKeys.messageSenderPostfix.value}")), findsNothing,
+          reason: "Expected message sender to not render");
+      expect(find.byKey(ValueKey("${ChatKeys.chatTilePrefix.value}2${MessageKeys.messageSenderPostfix.value}")), findsNothing,
+          reason: "Expected message sender to not render");
+    });
+  });
+}


### PR DESCRIPTION
This pull request includes several changes to the chat functionality, focusing on adding unique keys for widgets to improve testing and maintainability. Additionally, there are some minor code improvements and refactoring.

Key additions and improvements:

* **Introduction of Unique Keys:**
  * Added `ChatKeys` and `MessageKeys` classes to define unique keys for various chat and message-related widgets. (`lib/core/constants/keys.dart`)
  * Applied these keys to relevant widgets in `ChatScreen`, `ChatTileWidget`, and `MessageTileWidget` classes. (`lib/features/chat/view/screens/chat_screen.dart`, `lib/features/chat/view/widget/chat_tile_widget.dart`, `lib/features/chat/view/widget/message_tile_widget.dart`) [[1]](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caR212) [[2]](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caR276) [[3]](diffhunk://#diff-37028a13ef67dceae1d68402dd835b9f3139cd9e1f458af5c885078d9b29f81fR46) [[4]](diffhunk://#diff-37028a13ef67dceae1d68402dd835b9f3139cd9e1f458af5c885078d9b29f81fR74) [[5]](diffhunk://#diff-37028a13ef67dceae1d68402dd835b9f3139cd9e1f458af5c885078d9b29f81fL83-R106) [[6]](diffhunk://#diff-37028a13ef67dceae1d68402dd835b9f3139cd9e1f458af5c885078d9b29f81fR123) [[7]](diffhunk://#diff-37028a13ef67dceae1d68402dd835b9f3139cd9e1f458af5c885078d9b29f81fL147-R161) [[8]](diffhunk://#diff-37028a13ef67dceae1d68402dd835b9f3139cd9e1f458af5c885078d9b29f81fR176) [[9]](diffhunk://#diff-5df7ed88909e90fe3d0c7f8926979a4848c47369631823c86857249c2e3103a9R36-R41) [[10]](diffhunk://#diff-5df7ed88909e90fe3d0c7f8926979a4848c47369631823c86857249c2e3103a9R80) [[11]](diffhunk://#diff-5df7ed88909e90fe3d0c7f8926979a4848c47369631823c86857249c2e3103a9R109) [[12]](diffhunk://#diff-5df7ed88909e90fe3d0c7f8926979a4848c47369631823c86857249c2e3103a9R119)

* **Refactoring and Code Improvements:**
  * Removed an unnecessary return value in the `kmp` function. (`lib/core/utils.dart`)
  * Added missing imports for the newly introduced keys. (`lib/features/chat/view/screens/chat_screen.dart`, `lib/features/chat/view/widget/chat_tile_widget.dart`, `lib/features/chat/view/widget/message_tile_widget.dart`, `lib/features/stories/view/widget/chats_list.dart`) [[1]](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caR9) [[2]](diffhunk://#diff-37028a13ef67dceae1d68402dd835b9f3139cd9e1f458af5c885078d9b29f81fR4) [[3]](diffhunk://#diff-5df7ed88909e90fe3d0c7f8926979a4848c47369631823c86857249c2e3103a9R4) [[4]](diffhunk://#diff-4e76b5dca989731387bee4a83e2a689f43e1c44b5e7c2affe187eb9dd9f53094R3)
  * Introduced a variable to keep track of message indices in `ChatScreen`. (`lib/features/chat/view/screens/chat_screen.dart`)

These changes collectively improve the maintainability and testability of the chat-related code by ensuring that each widget has a unique key, which is crucial for automated testing and debugging.