### PR TITLE
fix: resolve errors thrown due to late initialized promises

### DIFF
--- a/lib/.env_example
+++ b/lib/.env_example
@@ -10,6 +10,7 @@ GITHUB_AUTH_URL=/auth/github
 # mocking
 USE_MOCK_DATA=false
 USE_MOCK_DATA_STORIES=true
+UPLOAD_MEDIA=false
 
 # Sockets Connection
 SOCKET_RECONNECT_DELAY_SECONDS=3

--- a/lib/core/models/message_model.g.dart
+++ b/lib/core/models/message_model.g.dart
@@ -30,13 +30,14 @@ class MessageModelAdapter extends TypeAdapter<MessageModel> {
       isPinned: fields[10] as bool,
       parentMessage: fields[11] as String?,
       localId: fields[12] as String,
+      isForward: fields[13] as bool,
     );
   }
 
   @override
   void write(BinaryWriter writer, MessageModel obj) {
     writer
-      ..writeByte(13)
+      ..writeByte(14)
       ..writeByte(0)
       ..write(obj.senderId)
       ..writeByte(1)
@@ -62,7 +63,9 @@ class MessageModelAdapter extends TypeAdapter<MessageModel> {
       ..writeByte(11)
       ..write(obj.parentMessage)
       ..writeByte(12)
-      ..write(obj.localId);
+      ..write(obj.localId)
+      ..writeByte(13)
+      ..write(obj.isForward);
   }
 
   @override

--- a/lib/features/auth/view_model/auth_view_model.g.dart
+++ b/lib/features/auth/view_model/auth_view_model.g.dart
@@ -6,7 +6,7 @@ part of 'auth_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$authViewModelHash() => r'2000b4ebfc215962fd9bc63a4ec6c708af246cbf';
+String _$authViewModelHash() => r'ae6759dae9fe3fde76135612b49967ee00a26a97';
 
 /// See also [AuthViewModel].
 @ProviderFor(AuthViewModel)

--- a/lib/features/chat/models/message_event_models.g.dart
+++ b/lib/features/chat/models/message_event_models.g.dart
@@ -17,19 +17,22 @@ class MessageEventAdapter extends TypeAdapter<MessageEvent> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return MessageEvent(
-      fields[0] as dynamic,
-      identifier: fields[1] as dynamic,
+      (fields[0] as Map).cast<String, dynamic>(),
+      msgId: fields[1] as String,
+      chatId: fields[2] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, MessageEvent obj) {
     writer
-      ..writeByte(2)
+      ..writeByte(3)
       ..writeByte(0)
       ..write(obj.payload)
       ..writeByte(1)
-      ..write(obj.identifier);
+      ..write(obj.msgId)
+      ..writeByte(2)
+      ..write(obj.chatId);
   }
 
   @override
@@ -54,19 +57,22 @@ class SendMessageEventAdapter extends TypeAdapter<SendMessageEvent> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return SendMessageEvent(
-      fields[0] as dynamic,
-      identifier: fields[1] as dynamic,
+      (fields[0] as Map).cast<String, dynamic>(),
+      msgId: fields[1] as String,
+      chatId: fields[2] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, SendMessageEvent obj) {
     writer
-      ..writeByte(2)
+      ..writeByte(3)
       ..writeByte(0)
       ..write(obj.payload)
       ..writeByte(1)
-      ..write(obj.identifier);
+      ..write(obj.msgId)
+      ..writeByte(2)
+      ..write(obj.chatId);
   }
 
   @override
@@ -91,19 +97,22 @@ class DeleteMessageEventAdapter extends TypeAdapter<DeleteMessageEvent> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return DeleteMessageEvent(
-      fields[0] as dynamic,
-      identifier: fields[1] as dynamic,
+      (fields[0] as Map).cast<String, dynamic>(),
+      msgId: fields[1] as String,
+      chatId: fields[2] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, DeleteMessageEvent obj) {
     writer
-      ..writeByte(2)
+      ..writeByte(3)
       ..writeByte(0)
       ..write(obj.payload)
       ..writeByte(1)
-      ..write(obj.identifier);
+      ..write(obj.msgId)
+      ..writeByte(2)
+      ..write(obj.chatId);
   }
 
   @override
@@ -128,19 +137,22 @@ class EditMessageEventAdapter extends TypeAdapter<EditMessageEvent> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return EditMessageEvent(
-      fields[0] as dynamic,
-      identifier: fields[1] as dynamic,
+      (fields[0] as Map).cast<String, dynamic>(),
+      msgId: fields[1] as String,
+      chatId: fields[2] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, EditMessageEvent obj) {
     writer
-      ..writeByte(2)
+      ..writeByte(3)
       ..writeByte(0)
       ..write(obj.payload)
       ..writeByte(1)
-      ..write(obj.identifier);
+      ..write(obj.msgId)
+      ..writeByte(2)
+      ..write(obj.chatId);
   }
 
   @override
@@ -165,18 +177,22 @@ class UpdateDraftEventAdapter extends TypeAdapter<UpdateDraftEvent> {
       for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
     };
     return UpdateDraftEvent(
-      fields[0] as dynamic,
+      (fields[0] as Map).cast<String, dynamic>(),
+      msgId: fields[1] as String,
+      chatId: fields[2] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, UpdateDraftEvent obj) {
     writer
-      ..writeByte(2)
+      ..writeByte(3)
       ..writeByte(0)
       ..write(obj.payload)
       ..writeByte(1)
-      ..write(obj.identifier);
+      ..write(obj.msgId)
+      ..writeByte(2)
+      ..write(obj.chatId);
   }
 
   @override

--- a/lib/features/chat/view/screens/chat_screen.dart
+++ b/lib/features/chat/view/screens/chat_screen.dart
@@ -86,6 +86,7 @@ class _ChatScreen extends ConsumerState<ChatScreen>
   @override
   void initState() {
     super.initState();
+    chatModel = widget.chatModel;
     _messageController.text = widget.chatModel?.draft ?? "";
     WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) {

--- a/lib/features/chat/view/screens/create_chat_screen.dart
+++ b/lib/features/chat/view/screens/create_chat_screen.dart
@@ -38,7 +38,7 @@ class _CreateChatScreen extends ConsumerState<CreateChatScreen>
   final ScrollController scrollController = ScrollController();
   final TextEditingController searchController = TextEditingController();
 
-  late Future<List<UserModel>> _usersFuture;
+  Future<List<UserModel>> _usersFuture = Future.value(<UserModel>[]);
   bool _isUserContentSet = false;
 
   @override
@@ -67,6 +67,7 @@ class _CreateChatScreen extends ConsumerState<CreateChatScreen>
     final ChatModel chat = ref
         .read(chatsViewModelProvider.notifier)
         .getChat(myUser, userInfo, ChatType.private);
+    debugPrint('Opening Chat: $chat');
     context.push(ChatScreen.route, extra: chat);
   }
 

--- a/lib/features/chat/view_model/chats_view_model.g.dart
+++ b/lib/features/chat/view_model/chats_view_model.g.dart
@@ -6,7 +6,7 @@ part of 'chats_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$chatsViewModelHash() => r'041605fdf548781078285ab56ecffd0d4b663fc6';
+String _$chatsViewModelHash() => r'7fef13e0ea95710fe0f29a44a2701ec6cfe0de72';
 
 /// See also [ChatsViewModel].
 @ProviderFor(ChatsViewModel)

--- a/lib/features/chat/view_model/chatting_controller.dart
+++ b/lib/features/chat/view_model/chatting_controller.dart
@@ -225,6 +225,7 @@ class ChattingController {
 
       if (response.appError != null) {
         debugPrint('Error: Could not create the chat');
+        return;
       } else {
         chatID = response.chat!.id;
         chatModel.id = chatID;

--- a/lib/features/user/view_model/user_view_model.g.dart
+++ b/lib/features/user/view_model/user_view_model.g.dart
@@ -6,7 +6,7 @@ part of 'user_view_model.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$userViewModelHash() => r'146aaaafddd8310f2d242c37c1cbbd1d46ab29f5';
+String _$userViewModelHash() => r'60d4856f1dbbf38f53042d83f7059b379b361469';
 
 /// See also [UserViewModel].
 @ProviderFor(UserViewModel)


### PR DESCRIPTION
This pull request includes several changes across different files to enhance the functionality and maintainability of the codebase. The most important changes are related to the improvements to the chat screen initialization that caused an error due to the late initialization.

### Chat screen improvements:

* [`lib/features/chat/view/screens/chat_screen.dart`](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caR89): Initialized `chatModel` in `initState` to ensure the draft message is correctly populated.
* [`lib/features/chat/view/screens/create_chat_screen.dart`](diffhunk://#diff-38e05ff60687907c5ca0aaed8949d332c702b8b8580ff4da48b6998d45c183e3L41-R41): Initialized `_usersFuture` with an empty list to prevent null issues and added a debug print statement when opening a chat. [[1]](diffhunk://#diff-38e05ff60687907c5ca0aaed8949d332c702b8b8580ff4da48b6998d45c183e3L41-R41) [[2]](diffhunk://#diff-38e05ff60687907c5ca0aaed8949d332c702b8b8580ff4da48b6998d45c183e3R70)

### Other changes:

* [`lib/.env_example`](diffhunk://#diff-cb6fb94a94b1901cac667aa2684ea01eda89e93708e933eeb12bd64dab513224R13): Added `UPLOAD_MEDIA` configuration to the environment example file.
* [`lib/features/chat/view_model/chatting_controller.dart`](diffhunk://#diff-666b7f422198509280981f188ffea81548526915faa4c9e521de951c2a96a384R228): Added a return statement to handle error scenarios in chat creation.