### PR TITLE
feat: add media settings UI

### DIFF
--- a/lib/core/routes/routes.dart
+++ b/lib/core/routes/routes.dart
@@ -32,6 +32,7 @@ import 'package:telware_cross_platform/features/user/view/screens/blocked_users.
 import 'package:telware_cross_platform/features/user/view/screens/change_email_screen.dart';
 import 'package:telware_cross_platform/features/user/view/screens/change_number_screen.dart';
 import 'package:telware_cross_platform/features/user/view/screens/change_username_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/data_and_storage_screen.dart';
 import 'package:telware_cross_platform/features/user/view/screens/invites_permissions_screen.dart';
 import 'package:telware_cross_platform/features/user/view/screens/last_seen_privacy_screen.dart';
 import 'package:telware_cross_platform/features/user/view/screens/phone_privacy_screen.dart';
@@ -41,6 +42,7 @@ import 'package:telware_cross_platform/features/user/view/screens/profile_photo_
 import 'package:telware_cross_platform/features/user/view/screens/self_destruct_screen.dart';
 import 'package:telware_cross_platform/features/user/view/screens/settings_screen.dart';
 import 'package:telware_cross_platform/features/user/view/screens/user_profile_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/wifi_media_screen.dart';
 
 import '../../features/chat/view/screens/pinned_messages_screen.dart';
 import '../../features/groups/view/screens/edit_group.dart';
@@ -87,6 +89,8 @@ class Routes {
   static const String addMembersScreen = AddMembersScreen.route;
   static const String membersScreen = MembersScreen.route;
   static const String captionScreen = CaptionScreen.route;
+  static const String dataAndStorageScreen = DataAndStorageScreen.route;
+  static const String wifiMediaScreen = WifiMediaScreen.route;
 
   static GoRouter appRouter(WidgetRef ref) => GoRouter(
         initialLocation: Routes.splash,
@@ -347,6 +351,14 @@ class Routes {
               );
             },
           ),
+          GoRoute(
+            path: Routes.dataAndStorageScreen,
+            builder: (context, state) => const DataAndStorageScreen(),
+          ),
+          GoRoute(
+            path: Routes.wifiMediaScreen,
+            builder: (context, state) => const WifiMediaScreen(),
+          )
         ],
       );
 

--- a/lib/features/user/view/screens/data_and_storage_screen.dart
+++ b/lib/features/user/view/screens/data_and_storage_screen.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:telware_cross_platform/core/models/user_model.dart';
+import 'package:telware_cross_platform/core/providers/user_provider.dart';
+import 'package:telware_cross_platform/core/routes/routes.dart';
+import 'package:telware_cross_platform/core/theme/dimensions.dart';
+import 'package:telware_cross_platform/core/theme/palette.dart';
+import 'package:telware_cross_platform/core/utils.dart';
+import 'package:telware_cross_platform/features/auth/view/widget/confirmation_dialog.dart';
+import 'package:telware_cross_platform/features/user/view/screens/invites_permissions_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/blocked_users.dart';
+import 'package:telware_cross_platform/features/user/view/screens/last_seen_privacy_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/phone_privacy_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/profile_photo_privacy_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/self_destruct_screen.dart';
+import 'package:telware_cross_platform/features/user/view/widget/settings_option_widget.dart';
+import 'package:telware_cross_platform/features/user/view/widget/settings_section.dart';
+import 'package:telware_cross_platform/features/user/view/widget/settings_toggle_switch_widget.dart';
+import 'package:telware_cross_platform/features/user/view/widget/toolbar_widget.dart';
+
+class DataAndStorageScreen extends ConsumerStatefulWidget {
+  static const String route = '/data-and-storage';
+
+  const DataAndStorageScreen({super.key});
+
+  @override
+  ConsumerState<DataAndStorageScreen> createState() =>
+      _DataAndStorageScreen();
+}
+
+class _DataAndStorageScreen extends ConsumerState<DataAndStorageScreen> {
+  final List<Map<String, dynamic>> profileSections = [
+    {
+      "title": "Disk and network usage",
+      "options": [
+        {
+          "icon": Icons.data_usage,
+          "text": 'Storage Usage',
+          "trailing": "62.4 MB",
+        },
+        {
+          "icon": Icons.analytics_outlined,
+          "text": 'Data Usage',
+          "trailing": "854.1 MB",
+        },
+      ],
+    }
+  ];
+  bool mobileMedia = true;
+  bool wifiMedia = true;
+  bool roamingMedia = true;
+  bool privateChats = false;
+  bool groups = false;
+  bool channels = false;
+  bool streamVideos = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const ToolbarWidget(
+        title: "Data and Storage",
+      ),
+      body: SingleChildScrollView(
+          child: Column(
+            children: [
+              ...List.generate(profileSections.length, (index) {
+                final section = profileSections[index];
+                final title = section["title"] ?? "";
+                final options = section["options"];
+                final trailing = section["trailing"] ?? "";
+                return Column(
+                  children: [
+                    SettingsSection(
+                      title: title,
+                      settingsOptions: options,
+                      trailing: trailing,
+                    ),
+                    const SizedBox(height: Dimensions.sectionGaps),
+                  ],
+                );
+              }),
+              SettingsSection(
+                title: "Automatic media download",
+                settingsOptions: [],
+                actions: [
+                  SettingsToggleSwitchWidget(
+                    text: 'When using mobile data',
+                    subtext: mobileMedia ? 'Photos, Videos (10 MB), Files (1 MB)' : 'Disabled',
+                    isChecked: mobileMedia,
+                    onToggle: (value) => setState(() {
+                      mobileMedia = value;
+                    }),
+                    onTap: (_) => showToastMessage("Coming soon"),
+                    oneFunction: false,
+                  ),
+                  SettingsToggleSwitchWidget(
+                    text: 'When connected to Wi-Fi',
+                    subtext: wifiMedia ? 'Photos, Videos (15 MB), Files (3 MB)' : 'Disabled',
+                    isChecked: wifiMedia,
+                    onToggle: (value) => setState(() {
+                      wifiMedia = value;
+                    }),                       // TODO: Marwan
+                    onTap: (_) => context.push(Routes.wifiMediaScreen),
+                    oneFunction: false,
+                  ),
+                  SettingsToggleSwitchWidget(
+                    text: 'When roaming',
+                    subtext: roamingMedia ? 'Photos' : 'Disabled',
+                    isChecked: roamingMedia,
+                    onToggle: (value) => setState(() {
+                      roamingMedia = value;
+                    }),
+                    onTap: (_) => showToastMessage("coming soon"),
+                    oneFunction: false,
+                  ),
+                  const SettingsOptionWidget(
+                    text: 'Reset Auto-Download Settings',
+                    color: Palette.error,
+                    showDivider: false,
+                  )
+                ],
+              ),
+              const SizedBox(height: Dimensions.sectionGaps),
+              SettingsSection(
+                title: "Save to Gallery",
+                settingsOptions: [],
+                actions: [
+                  SettingsToggleSwitchWidget(
+                    text: 'Private Chats',
+                    subtext: privateChats ? 'On' : 'Off',
+                    isChecked: privateChats,
+                    onToggle: (value) => setState(() {
+                      privateChats = value;
+                    }),
+                    onTap: (_) => showToastMessage("Coming soon"),
+                    oneFunction: false,
+                  ),
+                  SettingsToggleSwitchWidget(
+                    text: 'Groups',
+                    subtext: groups ? 'On' : 'Off',
+                    isChecked: groups,
+                    onToggle: (value) => setState(() {
+                      groups = value;
+                    }),
+                    onTap: (_) => showToastMessage("Coming soon"),
+                    oneFunction: false,
+                  ),
+                  SettingsToggleSwitchWidget(
+                    text: 'Channels',
+                    subtext: channels ? 'On' : 'Off',
+                    isChecked: channels,
+                    onToggle: (value) => setState(() {
+                      channels = value;
+                    }),
+                    onTap: (_) => showToastMessage("Coming soon"),
+                    oneFunction: false,
+                    showDivider: false,
+                  ),
+                ],
+              ),
+              const SizedBox(height: Dimensions.sectionGaps),
+              SettingsSection(
+                title: "Streaming",
+                settingsOptions: [],
+                actions: [
+                  SettingsToggleSwitchWidget(
+                    text: 'Stream Videos and Audio Files',
+                    isChecked: streamVideos,
+                    onToggle: (value) => setState(() {
+                      streamVideos = value;
+                    }),
+                    oneFunction: true,
+                    showDivider: false,
+                  ),
+                ],
+                trailing: "When possible, TelWare will start playing videos and music right away, without"
+                    " waiting for the files to fully download.",
+              ),
+              const SizedBox(height: Dimensions.sectionGaps),
+              const SettingsSection(
+                title: "Calls",
+                settingsOptions: [{
+                  "text": 'Use Less Data for Calls',
+                  "trailing": "Never"
+                }],
+              ),
+              const SizedBox(height: Dimensions.sectionGaps),
+              const SettingsSection(
+                title: "Proxy",
+                settingsOptions: [{
+                  "text": 'Proxy Settings',
+                }],
+              ),
+              const SizedBox(height: Dimensions.sectionGaps),
+              const SettingsSection(
+                settingsOptions: [{
+                  "text": 'Delete All Cloud Drafts',
+                }],
+              ),
+            ],
+          )),
+    );
+  }
+}

--- a/lib/features/user/view/screens/settings_screen.dart
+++ b/lib/features/user/view/screens/settings_screen.dart
@@ -52,7 +52,7 @@ class _SettingsScreen extends ConsumerState<SettingsScreen> {
         {
           "icon": Icons.pie_chart_outline,
           "text": 'Data and Storage',
-          "routes": 'locked'
+          "routes": Routes.dataAndStorageScreen
         },
         {
           "icon": Icons.battery_saver_outlined,

--- a/lib/features/user/view/screens/wifi_media_screen.dart
+++ b/lib/features/user/view/screens/wifi_media_screen.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:telware_cross_platform/core/models/user_model.dart';
+import 'package:telware_cross_platform/core/providers/user_provider.dart';
+import 'package:telware_cross_platform/core/routes/routes.dart';
+import 'package:telware_cross_platform/core/theme/dimensions.dart';
+import 'package:telware_cross_platform/core/theme/palette.dart';
+import 'package:telware_cross_platform/core/utils.dart';
+import 'package:telware_cross_platform/features/auth/view/widget/confirmation_dialog.dart';
+import 'package:telware_cross_platform/features/user/view/screens/invites_permissions_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/blocked_users.dart';
+import 'package:telware_cross_platform/features/user/view/screens/last_seen_privacy_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/phone_privacy_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/profile_photo_privacy_screen.dart';
+import 'package:telware_cross_platform/features/user/view/screens/self_destruct_screen.dart';
+import 'package:telware_cross_platform/features/user/view/widget/settings_section.dart';
+import 'package:telware_cross_platform/features/user/view/widget/settings_toggle_switch_widget.dart';
+import 'package:telware_cross_platform/features/user/view/widget/toolbar_widget.dart';
+
+class WifiMediaScreen extends ConsumerStatefulWidget {
+  static const String route = '/data-and-storage/wifi';
+
+  const WifiMediaScreen({super.key});
+
+  @override
+  ConsumerState<WifiMediaScreen> createState() =>
+      _WifiMediaScreen();
+}
+
+class _WifiMediaScreen extends ConsumerState<WifiMediaScreen> {
+  late List<Map<String, dynamic>> profileSections;
+  bool photos = true;
+  bool videos = true;
+  bool files = true;
+  bool stories = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: const ToolbarWidget(
+        title: "Data and Storage",
+      ),
+      body: SingleChildScrollView(
+          child: Column(
+            children: [
+              const SettingsSection(
+                title: 'Data usage',
+                settingsOptions: [],
+                actions: [
+                  LowMediumHighSlider(),
+                ],
+              ),
+              const SizedBox(height: Dimensions.sectionGaps),
+              SettingsSection(
+                title: 'Types of media',
+                settingsOptions: const [],
+                actions: [
+                  SettingsToggleSwitchWidget(
+                    text: 'Photos',
+                    subtext: photos ? 'On in all chats' : 'Off',
+                    isChecked: photos,
+                    onToggle: (value) => setState(() {
+                      photos = value;
+                    }),
+                    onTap: (context) {},
+                    oneFunction: false,
+                  ),
+                  SettingsToggleSwitchWidget(
+                    text: 'Videos',
+                    subtext: videos ? 'Up to 15.0 MB in all chats' : 'Off',
+                    isChecked: videos,
+                    onToggle: (value) => setState(() {
+                      videos = value;
+                    }),
+                    onTap: (context) {},
+                    oneFunction: false,
+                  ),
+                  SettingsToggleSwitchWidget(
+                    text: 'Files',
+                    subtext: files ? 'Up to 3.0 MB in all chats' : 'Off',
+                    isChecked: files,
+                    onToggle: (value) => setState(() {
+                      files = value;
+                    }),
+                    onTap: (context) {},
+                    oneFunction: false,
+                  ),
+                  SettingsToggleSwitchWidget(
+                    text: 'Stories',
+                    subtext: stories ? 'On' : 'Off',
+                    isChecked: stories,
+                    onToggle: (value) => setState(() {
+                      stories = value;
+                    }),
+                    onTap: (context) {},
+                    oneFunction: false,
+                    showDivider: false,
+                  ),
+                ],
+                trailing: "Voice messages are tiny, so they're always downloaded automatically.",
+              ),
+            ],
+          )),
+    );
+  }
+}
+
+class LowMediumHighSlider extends StatefulWidget {
+  const LowMediumHighSlider({super.key});
+
+  @override
+  _LowMediumHighSliderState createState() => _LowMediumHighSliderState();
+}
+
+class _LowMediumHighSliderState extends State<LowMediumHighSlider> {
+  double _currentValue = 0; // Start at Low
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        const Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text("Low"),
+            Text("Medium"),
+            Text("High"),
+          ],
+        ),
+        SliderTheme(
+          data: SliderTheme.of(context).copyWith(
+            activeTrackColor: Palette.primary,
+            inactiveTrackColor: Palette.primary.withOpacity(0.3),
+            thumbColor: Palette.primary,
+            overlayColor: Palette.primary.withOpacity(0.2),
+            valueIndicatorColor: Palette.primary,
+            activeTickMarkColor: Palette.primary,
+            inactiveTickMarkColor: Palette.primary.withOpacity(0.5),
+            trackHeight: 4.0,
+            tickMarkShape: _CustomTickMarkShape(
+              tickMarkRadius: 5.0,
+              borderColor: Palette.secondary,
+            ),
+            thumbShape: _CustomThumbShape(
+              thumbRadius: 7.0,
+              borderColor: Palette.secondary,
+            ),
+          ),
+          child: Slider(
+            value: _currentValue,
+            min: 0,
+            max: 2,
+            divisions: 2, // Divide into three steps
+            onChanged: (value) {
+              setState(() {
+                _currentValue = value;
+              });
+            },
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _CustomTickMarkShape extends SliderTickMarkShape {
+  final double tickMarkRadius;
+  final Color borderColor;
+
+  _CustomTickMarkShape({
+    required this.tickMarkRadius,
+    required this.borderColor,
+  });
+
+  @override
+  Size getPreferredSize({
+    required SliderThemeData sliderTheme,
+    bool isEnabled = false,
+  }) {
+    return Size.fromRadius(tickMarkRadius);
+  }
+
+  @override
+  void paint(
+      PaintingContext context,
+      Offset center, {
+        required RenderBox parentBox,
+        required SliderThemeData sliderTheme,
+        required Animation<double> enableAnimation,
+        required bool isEnabled,
+        required TextDirection textDirection,
+        required Offset thumbCenter,
+      }) {
+    final double opacity = isEnabled ? 1.0 : 0.2;
+
+    final Paint borderPaint = Paint()
+      ..color = borderColor.withOpacity(opacity)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2.0;
+
+    final Paint fillPaint = Paint()
+      ..color = (sliderTheme.activeTickMarkColor ?? Colors.transparent).withOpacity(opacity)
+      ..style = PaintingStyle.fill;
+
+    // Draw the filled circle
+    context.canvas.drawCircle(center, tickMarkRadius, fillPaint);
+    // Draw the border around the circle
+    context.canvas.drawCircle(center, tickMarkRadius, borderPaint);
+  }
+}
+
+class _CustomThumbShape extends SliderComponentShape {
+  final double thumbRadius;
+  final Color borderColor;
+  final double borderWidth;
+
+  _CustomThumbShape({
+    required this.thumbRadius,
+    required this.borderColor,
+    this.borderWidth = 2.0,
+  });
+
+  @override
+  Size getPreferredSize(bool isEnabled, bool isDiscrete) {
+    return Size.fromRadius(thumbRadius);
+  }
+
+  @override
+  void paint(
+      PaintingContext context,
+      Offset center, {
+        required Animation<double> activationAnimation,
+        required Animation<double> enableAnimation,
+        required bool isDiscrete,
+        required TextPainter labelPainter,
+        required RenderBox parentBox,
+        required Size sizeWithOverflow,
+        required SliderThemeData sliderTheme,
+        required TextDirection textDirection,
+        required double textScaleFactor,
+        required double value,
+      }) {
+    final Paint borderPaint = Paint()
+      ..color = borderColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = borderWidth;
+
+    final Paint fillPaint = Paint()
+      ..color = sliderTheme.thumbColor ?? Colors.transparent
+      ..style = PaintingStyle.fill;
+
+    // Draw the filled circle
+    context.canvas.drawCircle(center, thumbRadius, fillPaint);
+    // Draw the border around the circle
+    context.canvas.drawCircle(center, thumbRadius, borderPaint);
+  }
+}
+


### PR DESCRIPTION
This pull request introduces new screens for managing data and storage settings in the application. It includes changes to the routing configuration and the addition of two new screens: `DataAndStorageScreen` and `WifiMediaScreen`.

New screens and routing updates:

* Added imports for `DataAndStorageScreen` and `WifiMediaScreen` in `lib/core/routes/routes.dart`. [[1]](diffhunk://#diff-c7a40a2a3066d097c9a8239b61cd20f1ee4663effd27f47c673ade0bf9e99c55R35) [[2]](diffhunk://#diff-c7a40a2a3066d097c9a8239b61cd20f1ee4663effd27f47c673ade0bf9e99c55R45)
* Added static route constants and corresponding `GoRoute` entries for `DataAndStorageScreen` and `WifiMediaScreen` in `lib/core/routes/routes.dart`. [[1]](diffhunk://#diff-c7a40a2a3066d097c9a8239b61cd20f1ee4663effd27f47c673ade0bf9e99c55R92-R93) [[2]](diffhunk://#diff-c7a40a2a3066d097c9a8239b61cd20f1ee4663effd27f47c673ade0bf9e99c55R354-R361)
* Updated the settings screen to navigate to the new `DataAndStorageScreen`.

Implementation of new screens:

* Created `DataAndStorageScreen` with various settings options and toggle switches for managing data usage and media download preferences.
* Created `WifiMediaScreen` with settings for managing media types and data usage when connected to Wi-Fi, including a custom slider for selecting data usage levels.