### PR TITLE
perf: fix reloading of chat screen with draft

### DIFF
--- a/lib/features/chat/view/screens/chat_screen.dart
+++ b/lib/features/chat/view/screens/chat_screen.dart
@@ -68,8 +68,6 @@ class _ChatScreen extends ConsumerState<ChatScreen>
   List<MessageModel> pinnedMessages = [];
   int indexInPinnedMessage = 0;
 
-  late Timer _draftTimer;
-
   late ChatModel chatModel;
   bool isSearching = false;
   bool isShowAsList = false;
@@ -79,7 +77,6 @@ class _ChatScreen extends ConsumerState<ChatScreen>
   bool isTextEmpty = true;
   bool showMuteOptions = false;
   bool isAllowedToSend = true;
-  String _previousDraft = "";
 
   // ignore: prefer_final_fields
   int _currentMatch = 1;
@@ -89,17 +86,14 @@ class _ChatScreen extends ConsumerState<ChatScreen>
   Map<int, List<MapEntry<int, int>>> _messageMatches = {};
   List<int> _messageIndices = [];
 
-  late DateTime _lastTypeTimer;
-
   late ChatType type;
 
   @override
   void initState() {
     super.initState();
-    _lastTypeTimer = DateTime.now();
     _messageController.text = widget.chatModel?.draft ?? "";
     _messageController.addListener(() {
-      _lastTypeTimer = DateTime.now();
+      _updateDraft(false);
     });
 
     WidgetsBinding.instance.addObserver(this);
@@ -111,12 +105,6 @@ class _ChatScreen extends ConsumerState<ChatScreen>
     _chosenAnimation = utils.getRandomLottieAnimation();
     // Initialize the AudioRecorderService
     _audioRecorderService = AudioRecorderService(updateUI: setState);
-    _draftTimer = Timer.periodic(const Duration(milliseconds: 50), (timer) {
-      if (_previousDraft != _messageController.text) {
-        _updateDraft();
-        _previousDraft = _messageController.text;
-      }
-    });
   }
 
   @override
@@ -126,17 +114,16 @@ class _ChatScreen extends ConsumerState<ChatScreen>
     _audioRecorderService.dispose();
     SystemChannels.textInput.invokeMethod('TextInput.hide');
     WidgetsBinding.instance.removeObserver(this); // Remove the observer
+
     super.dispose();
   }
 
-  void _updateDraft() async {
-    // TODO : server return 500 status code every time try to fix it ASAP
+  void _updateDraft(bool saveLocal) {
     if (!mounted) return;
     final currentDraft = _messageController.text;
     ref
         .read(chattingControllerProvider)
-        .updateDraft(chatModel, currentDraft);
-    return;
+        .updateDraft(chatModel, currentDraft, saveLocal);
   }
 
   void _updateChatMessages(List<MessageModel> messages) async {
@@ -294,7 +281,7 @@ class _ChatScreen extends ConsumerState<ChatScreen>
       parentMessage: replyMessage?.id,
     );
     _messageController.clear();
-    _updateDraft();
+    _updateDraft(true);
     ref.read(chattingControllerProvider).sendMsg(
           content: newMessage.content!,
           msgType: newMessage.messageType,
@@ -435,8 +422,7 @@ class _ChatScreen extends ConsumerState<ChatScreen>
             : "$membersNumber subscribers${membersNumber > 1 ? "s" : ""}";
 
     _isMuted = chatModel.isMuted;
-    if (chatModel.draft != null && chatModel.draft!.isNotEmpty &&
-        _lastTypeTimer.isBefore(DateTime.now().subtract(const Duration(seconds: 1)))) {
+    if (chatModel.draft != null && chatModel.draft!.isNotEmpty) {
       _messageController.text = chatModel.draft ?? '';
     }
     chatContent = _generateChatContentWithDateLabels(messages);
@@ -469,7 +455,7 @@ class _ChatScreen extends ConsumerState<ChatScreen>
                           _messageMatches.clear();
                         });
                       } else {
-                        _updateDraft();
+                        _updateDraft(true);
                         context.pop();
                       }
                     },


### PR DESCRIPTION
This pull request includes several changes to the `ChatScreen` and `ChattingController` classes to improve the handling of draft messages and simplify the codebase. The most important changes include removing unused variables, modifying the `_updateDraft` method, and updating the `updateDraft` method in the `ChattingController` class.

Improvements to draft message handling:

* [`lib/features/chat/view/screens/chat_screen.dart`](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caL71-L72): Removed unused variables `_draftTimer`, `_previousDraft`, and `_lastTypeTimer` from the `_ChatScreen` class. [[1]](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caL71-L72) [[2]](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caL82) [[3]](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caL92-R96)
* [`lib/features/chat/view/screens/chat_screen.dart`](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caR117-R126): Modified the `_updateDraft` method to include a `saveLocal` parameter to control whether the draft should be saved locally.
* [`lib/features/chat/view/screens/chat_screen.dart`](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caL297-R284): Updated calls to `_updateDraft` to pass the appropriate `saveLocal` parameter. [[1]](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caL297-R284) [[2]](diffhunk://#diff-281be3aec1979c339ce805684e2dc63edd1f75e7bd089ab557c90b0b3cbde7caL472-R458)

Codebase simplification:

* [`lib/features/chat/view_model/chatting_controller.dart`](diffhunk://#diff-666b7f422198509280981f188ffea81548526915faa4c9e521de951c2a96a384R54): Added a `_lastOpenedChatId` variable to the `ChattingController` class to track the last opened chat ID.
* [`lib/features/chat/view_model/chatting_controller.dart`](diffhunk://#diff-666b7f422198509280981f188ffea81548526915faa4c9e521de951c2a96a384L668-R670): Modified the `updateDraft` method to include an `updateLocal` parameter and handle the local update logic accordingly. [[1]](diffhunk://#diff-666b7f422198509280981f188ffea81548526915faa4c9e521de951c2a96a384L668-R670) [[2]](diffhunk://#diff-666b7f422198509280981f188ffea81548526915faa4c9e521de951c2a96a384R708-R721)